### PR TITLE
automated ecs roles created and used by infrastructure

### DIFF
--- a/terraform/auto_scaling.tf
+++ b/terraform/auto_scaling.tf
@@ -4,7 +4,7 @@ resource "aws_appautoscaling_target" "target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  role_arn           = var.ecs_autoscale_role
+  role_arn           = aws_iam_role.ecsAutoScaleRole.arn
   min_capacity       = 3
   max_capacity       = 6
 }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -18,7 +18,7 @@ data "template_file" "cb_app" {
 
 resource "aws_ecs_task_definition" "app" {
   family                   = "cb-app-task"
-  execution_role_arn       = var.ecs_task_execution_role
+  execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.fargate_cpu
@@ -45,6 +45,6 @@ resource "aws_ecs_service" "main" {
     container_port   = var.app_port
   }
 
-  depends_on = [aws_alb_listener.front_end]
+  depends_on = [aws_alb_listener.front_end,aws_iam_role_policy_attachment.ecsTaskExecutionRole]
 }
 

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -1,0 +1,48 @@
+data "aws_iam_policy_document" "ecsTaskExecutionRole" {
+  version = "2012-10-17"
+  statement {
+    sid = ""
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecsTaskExecutionRole" {
+  name               = var.ecsTaskExecutionRoleName
+  assume_role_policy = data.aws_iam_policy_document.ecsTaskExecutionRole.json
+}
+
+#EASY FETCH OF POLICY DOCUMENT FROM OFFICIAL POLICY ARN. THIS WAY WE SPARE A RESOURCE.
+resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole" {
+  role       = aws_iam_role.ecsTaskExecutionRole.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "ecsAutoScaleRole" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["application-autoscaling.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecsAutoScaleRole" {
+  name               = var.ecsAutoScaleRoleName
+  assume_role_policy = data.aws_iam_policy_document.ecsAutoScaleRole.json
+}
+
+#EASY FETCH OF POLICY DOCUMENT FROM OFFICIAL POLICY ARN. THIS WAY WE SPARE A RESOURCE.
+resource "aws_iam_role_policy_attachment" "ecsAutoScaleRole" {
+  role       = aws_iam_role.ecsAutoScaleRole.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,6 +5,16 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
+variable "ecsTaskExecutionRoleName" {
+  description = "ECS Task execution Role name"
+  default = "myEcsTaskExecutionRole"
+}
+
+variable "ecsAutoScaleRoleName" {
+  description = "ECS Auto Scale Role Name"
+  default = "myEcsAutoScaleRole"
+}
+
 variable "az_count" {
   description = "Number of AZs to cover in a given region"
   default     = "2"
@@ -23,16 +33,6 @@ variable "app_port" {
 variable "app_count" {
   description = "Number of docker containers to run"
   default     = 3
-}
-
-variable "ecs_autoscale_role" {
-  description = "Role arn for the ecsAutoscaleRole"
-  default     = "arn:aws:iam::309154556741:role/ecsAutoscaleRoles"
-}
-
-variable "ecs_task_execution_role" {
-  description = "Role arn for the ecsTaskExecutionRole"
-  default     = "arn:aws:iam::309154556741:role/ecsTaskExecutionRole"
 }
 
 variable "health_check_path" {


### PR DESCRIPTION
Hello! i automated the auto scale - and task exection roles for the ecs service, which is included in your medium series part1.
With this addition this could be a standalone example for terraform usage.

NOTE: The policy attachment should be a dependency for the  "aws_ecs_service" because of race condition issues at destroy time. more info at : https://www.terraform.io/docs/providers/aws/r/ecs_service.html

Happy Coding,
fullammo