### PR TITLE
remove role from aws_appautoscaling_target

### DIFF
--- a/terraform/auto_scaling.tf
+++ b/terraform/auto_scaling.tf
@@ -4,7 +4,6 @@ resource "aws_appautoscaling_target" "target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  role_arn           = aws_iam_role.ecs_auto_scale_role.arn
   min_capacity       = 3
   max_capacity       = 6
 }

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -24,29 +24,3 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
-
-# ECS auto scale role data
-data "aws_iam_policy_document" "ecs_auto_scale_role" {
-  version = "2012-10-17"
-  statement {
-    effect = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["application-autoscaling.amazonaws.com"]
-    }
-  }
-}
-
-# ECS auto scale role
-resource "aws_iam_role" "ecs_auto_scale_role" {
-  name               = var.ecs_auto_scale_role_name
-  assume_role_policy = data.aws_iam_policy_document.ecs_auto_scale_role.json
-}
-
-# ECS auto scale role policy attachment
-resource "aws_iam_role_policy_attachment" "ecs_auto_scale_role" {
-  role       = aws_iam_role.ecs_auto_scale_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,11 +10,6 @@ variable "ecs_task_execution_role_name" {
   default = "myEcsTaskExecutionRole"
 }
 
-variable "ecs_auto_scale_role_name" {
-  description = "ECS auto scale role Name"
-  default = "myEcsAutoScaleRole"
-}
-
 variable "az_count" {
   description = "Number of AZs to cover in a given region"
   default     = "2"


### PR DESCRIPTION
fixes idempotency issue with the role being replaced by AWS's service linked
role. (see https://github.com/azavea/terraform-aws-ecs-web-service/pull/13)

fixes #13 