### PR TITLE
Fix upper bound on scale down action

### DIFF
--- a/terraform/auto_scaling.tf
+++ b/terraform/auto_scaling.tf
@@ -42,7 +42,7 @@ resource "aws_appautoscaling_policy" "down" {
     metric_aggregation_type = "Maximum"
 
     step_adjustment {
-      metric_interval_lower_bound = 0
+      metric_interval_upper_bound = 0
       scaling_adjustment          = -1
     }
   }


### PR DESCRIPTION
I found this setting to cause the scale down action to file without any error text. I stumbled on [this post](https://superuser.com/a/1508956) that had the suggestion. After making the change, the service scaled down immediately in the alarm state.